### PR TITLE
Added catfs and goofys's "allow_other" optional parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update && apk add gcc ca-certificates openssl musl-dev git fuse syslog-n
 ENV GOOFYS_VERSION 0.23.1
 RUN curl --fail -sSL -o /usr/local/bin/goofys https://github.com/kahing/goofys/releases/download/v${GOOFYS_VERSION}/goofys \
     && chmod +x /usr/local/bin/goofys
+RUN curl -sSL -o /usr/local/bin/catfs https://github.com/kahing/catfs/releases/download/v0.8.0/catfs && chmod +x /usr/local/bin/catfs
 
 ARG ENDPOINT
 ENV MOUNT_DIR /mnt/s3

--- a/rootfs/usr/bin/run.sh
+++ b/rootfs/usr/bin/run.sh
@@ -2,4 +2,6 @@
 
 syslog-ng -f /etc/syslog-ng/syslog-ng.conf
 
-goofys -f ${ENDPOINT:+--endpoint $ENDPOINT} --region $REGION --stat-cache-ttl $STAT_CACHE_TTL --type-cache-ttl $TYPE_CACHE_TTL --dir-mode $DIR_MODE --file-mode $FILE_MODE --uid $UID --gid $GID -o nonempty $BUCKET $MOUNT_DIR
+[[ "$UID" -ne "0" ]] && MOUNT_ACCESS="allow_other" || MOUNT_ACCESS="nonempty"
+
+goofys -f ${ENDPOINT:+--endpoint $ENDPOINT} --region $REGION --stat-cache-ttl $STAT_CACHE_TTL --type-cache-ttl $TYPE_CACHE_TTL --dir-mode $DIR_MODE --file-mode $FILE_MODE --uid $UID --gid $GID -o $MOUNT_ACCESS $BUCKET $MOUNT_DIR


### PR DESCRIPTION
Goofys needs to be explicitly said "allow_other" to allow other users to use the filesystem (without it you won't be able to use it, and will see awkward ????? permissions with other users).
I also added catfs since it might be required when setting the cache time to 0s (and I had nasty issues with a cache and 3 containers using the FS).  

This was the last thing missing, I'm able to use goofys with an other user and achieved my needs.